### PR TITLE
Support API's with non-integer versions

### DIFF
--- a/shoogle/commands/execute.py
+++ b/shoogle/commands/execute.py
@@ -33,7 +33,11 @@ def add_parser(main_parser, name):
 
 def run(options):
     """Run command execute."""
-    service_id, resource_name, method_name = lib.pad_list(options.api_path.split(".", 2), 3)
+    components = options.api_path.split(".")
+    if len(components) > 1 and components[1].isdigit():
+        components = [f"{components[0]}.{components[1]}"] + components[2:]
+    service_id, resource_name, method_name = lib.pad_list(components, 3)
+
     request_fd = (sys.stdin if options.json_request == "-" else open(options.json_request))
     method_options = lib.load_json(request_fd.read())
     try:

--- a/shoogle/commands/show.py
+++ b/shoogle/commands/show.py
@@ -16,8 +16,11 @@ def add_parser(subparsers, name):
         help="SERVICE:VERSION.RESOURCE.METHOD")
 
 def run(options):
-    parts = options.api_path.split(".", 2)
+    parts = options.api_path.split(".")
+    if len(parts) >= 2 and parts[1].isdigit():
+        parts = [f"{parts[0]}.{parts[1]}"] + parts[2:]
     service_id, resource_name, method_name = lib.pad_list(parts, 3)
+
     if resource_name is None:
         show_services(service_id, options)
     elif method_name is None:

--- a/tests/test_shoogle.py
+++ b/tests/test_shoogle.py
@@ -156,6 +156,11 @@ class TestShoogle(unittest.TestCase):
             e = main(["execute", "tasks:v1.tasks.get", request_file])
             self.assertEqual(0, e.status)
             self.assertIn('Missing required parameter', e.err)
+
+    def test_main_show_with_fractional_version(self):
+        e = main(["show", "content:v2.1"])
+
+        self.assertTrue("content:v2.1" in e.out)
         
 if __name__ == '__main__':
     sys.exit(unittest.main())


### PR DESCRIPTION
The code did not parse function paths for API's whose versions were not
integers. Code is added to detect the fractional part, and add it back
to the version string.

Fixes https://github.com/tokland/shoogle/issues/10